### PR TITLE
update to latest GEE client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-pycrypto==2.6.1
 sql2gee==0.3.0
 Flask==1.0.3
 pycrypto==2.6.1
-earthengine-api==0.1.178
-google-api-python-client==1.7.3
+earthengine-api==0.1.272
+google-api-python-client==1.12.8
 CTRegisterMicroserviceFlask==0.4.0
 requests==2.12.4
 hyp==0.6.0


### PR DESCRIPTION
Not sure how to test this locally - or whether it would even make sense outside of the actual k8s cluster

Anyway, I have bumped the `earthengine-api` to the latest version - it's pre-v1 so semantic versioning should not apply and things may break between any revisions, in theory.

Other than the EE client, I have only bumped `google-api-python-client` but only to the latest minor revision for 1.x, as it's currently on 2.x and I suppose this may break half of the universe.